### PR TITLE
Move to a `config` scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Add authsense to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  #[{:authsense, "~> 0.0.1"}]
-  [{:authsense, git: "https://github.com/rstacruz/authsense.git"}]
+  [{:authsense, "~> 0.2.0"}]
 end
 ```
 
@@ -30,20 +29,20 @@ You can then call some helpers for authentication:
 
 ```elixir
 # For login actions
-Authsense.Service.authenticate(changeset)  #=> {:ok, user} or {:error, changeset_with_errors}
-Authsense.Service.authenticate({ "userid", "password" })  #=> %User{} | nil
+authenticate(changeset)  #=> {:ok, user} or {:error, changeset_with_errors}
+authenticate({ "userid", "password" })  #=> %User{} | nil
 ```
 
 ```elixir
 # For login/logout actions
-conn |> Authsense.Plug.put_current_user(user)  # login
-conn |> Authsense.Plug.put_current_user(nil)   # logout
+conn |> put_current_user(user)  # login
+conn |> put_current_user(nil)   # logout
 ```
 
 ```elixir
 # For model changesets
 changeset
-|> Authsense.Service.generate_hashed_password()
+|> generate_hashed_password()
 ```
 
 ```elixir
@@ -53,7 +52,7 @@ plug :fetch_current_user
 conn.assigns.current_user  #=> %User{} | nil
 ```
 
-Please consult the [Authsense documentation](http://ricostacruz.com/authsense/) for more.
+Please consult the [Authsense documentation](http://ricostacruz.com/authsense/) detailed info.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -15,51 +15,40 @@ def deps do
 end
 ```
 
-Ensure authsense is started before your application:
-
-```elixir
-def application do
-  [applications: [:authsense]]
-end
-```
-
 ## Overview
 
 Please consult the [Authsense documentation](http://ricostacruz.com/authsense/) for full details.
 
-Create a module:
+Configure authsense:
 
 ```elixir
-defmodule Myapp.Auth do
-  use Authsense,
-    repo: Myapp.Auth,
-    model: Myapp.User
-end
+config :authsense, Myapp.User,
+   repo: Myapp.Repo
 ```
 
 You can then call some helpers for authentication:
 
 ```elixir
 # For login actions
-Auth.authenticate(changeset)  #=> {:ok, user} or {:error, changeset_with_errors}
-Auth.authenticate({ "userid", "password" })  #=> %User{} | nil
+Authsense.Service.authenticate(changeset)  #=> {:ok, user} or {:error, changeset_with_errors}
+Authsense.Service.authenticate({ "userid", "password" })  #=> %User{} | nil
 ```
 
 ```elixir
 # For login/logout actions
-conn |> Auth.put_current_user(user)  # login
-conn |> Auth.put_current_user(nil)   # logout
+conn |> Authsense.Plug.put_current_user(user)  # login
+conn |> Authsense.Plug.put_current_user(nil)   # logout
 ```
 
 ```elixir
 # For model changesets
 changeset
-|> Auth.generate_hashed_password()
+|> Authsense.Service.generate_hashed_password()
 ```
 
 ```elixir
 # For controllers
-import Auth
+import Authsense.Plug
 plug :fetch_current_user
 conn.assigns.current_user  #=> %User{} | nil
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,3 +22,6 @@ config :ex_unit, :capture_log, true
 config :authsense,
   Authsense.Test.User,
   repo: Authsense.Test.Repo
+
+config :comeonin, :bcrypt_log_rounds, 4
+config :comeonin, :pbkdf2_rounds, 1

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,3 +18,7 @@ else
 end
 
 config :ex_unit, :capture_log, true
+
+config :authsense,
+  Authsense.Test.User,
+  repo: Authsense.Test.Repo

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -17,15 +17,16 @@ schema "users" do
 end
 ```
 
-Use `Auth.generate_hashed_password/2` for their changesets. This way, when
-updating or creating users, any new `:password` fields will be hashed into
-`:hashed_password`.
+Use `Authsense.Serviec.generate_hashed_password/2` for their changesets. This
+way, when updating or creating users, any new `:password` fields will be hashed
+into `:hashed_password`.
 
 ```elixir
-def changeset(model, params \\ :empty) do
+# ecto 2.0
+def changeset(model, params \\ []) do
   model
-  |> cast(params, @required_fields, @optional_fields)
-  |> Auth.generate_hashed_password()
+  |> cast(params, [:email, :password, :password_confirmation])
+  |> Authsense.Service.generate_hashed_password()
   |> validate_confirmation(:password, message: "password confirmation doesn't match")
   |> unique_constraint(:email)
 end
@@ -33,30 +34,30 @@ end
 
 ## Login page
 
-I typically like having an `AuthController` handle all auth-related actions.
+I typically like having an `SessionController` handle logins and logouts.
 
 ```elixir
 # web/router.ex
-get "/login", AuthController, :login
-post "/login", AuthController, :login_create
-get "/logout", AuthController, :logout
+get "/login",  SessionController, :new
+post "/login", SessionController, :create
+get "/logout", SessionController, :delete
 ```
 
-`AuthController.login` gets you a form. Use a changeset here.
+`SessionController.new` gets you a form. Use a changeset here.
 
 ```elixir
-# web/controllers/auth_controller.ex
+# web/controllers/session_controller.ex
 
-def login(conn, params) do
+def new(conn, params) do
   changeset = User.changeset(%User{})
-  render(conn, "login.html", changeset: changeset)
+  render(conn, "new.html", changeset: changeset)
 end
 ```
 
-`AuthController.login_create` logs someone in (creates a session) using `Auth.put_current_user/2`.
+`SessionController.create` logs someone in (creates a session) using `Authsense.Plug.put_current_user/2`.
 
 ```elixir
-def login_create(conn, %{"user" => user_params}) do
+def create(conn, %{"user" => user_params}) do
   changeset = User.changeset(%User{}, user_params)
 
   case Auth.authenticate(changeset) do
@@ -66,17 +67,17 @@ def login_create(conn, %{"user" => user_params}) do
       |> put_flash(:info, "Welcome.")
       |> redirect(to: "/")
     {:error, changeset} ->
-      render(conn, "login.html", changeset: changeset)
+      render(conn, "new.html", changeset: changeset)
   end
 end
 ```
 
-`AuthController.logout` logs you out using `Auth.put_current_user/2`.
+`sessionController.delete` logs you out using `Authsense.Plug.put_current_user/2`.
 
 ```elixir
 def logout(conn, _params) do
   conn
-  |> Auth.put_current_user(nil)
+  |> Authsense.Plug.put_current_user(nil)
   |> put_flash(:info, "You've been logged out.")
   |> redirect(to: "/")
 end
@@ -88,38 +89,11 @@ This is just a simple `create` action for users.
 
 ## Secure pages
 
-To make certain pages, you can implement your own `ensure_authenticated` helper.
-
-```elixir
-defmodule Myapp.Auth do
-  import Phoenix.Controller, only: [put_flash: 3, redirect: 2]
-
-  def ensure_authenticated(conn, _opts) do
-    if Map.get(conn.assigns, :current_user) do
-      conn
-    else
-      conn
-      |> put_flash(:error, "You have to be logged in to do that.")
-      |> redirect(to: "/")
-    end
-  end
-end
-```
-
-Use it as a plug after using `Auth`.
-
-```elixir
-defmodule Myapp.MyController do
-  import Auth
-
-  plug :fetch_current_user
-  plug :ensure_authenticated
-end
-```
+_(To be documented)_
 
 ## Token-based authentication
 
-You can implement your own version of `Auth.fetch_current_user/2` to
+You can implement your own version of `Authsense.Plug.fetch_current_user/2` to
 authenticate based on something else other than passwords.
 
 ```elixir
@@ -139,8 +113,6 @@ end
 pipeline :api do
   plug :authenticate_by_token
 end
-
-# add `import Auth` to your web/web.ex
 ```
 
 ## Forgot your password

--- a/lib/authsense.ex
+++ b/lib/authsense.ex
@@ -99,7 +99,7 @@ defmodule Authsense do
 
       authenticate({"rico@gmail.com", "password"})
 
-  But you may pass options to it to override:
+  But you may pass options to it to override the config:
 
       authenticate({"rico@gmail.com", "password"},
         hashed_password_field: :hashed_password)

--- a/lib/authsense.ex
+++ b/lib/authsense.ex
@@ -3,7 +3,7 @@ defmodule Authsense do
   Sensible authentication helpers for Phoenix/Ecto.
 
   ### Basic use
-  Create your own module and use Authsense.
+  Specify your configuration via Mix.Config in `config/config.exs`.
 
       config :authsense, Myapp.Model,
         repo: Myapp.Repo
@@ -38,6 +38,19 @@ defmodule Authsense do
       |> generate_hashed_password()
 
   ## Configuration
+  Specify your configuration via Mix.Config in `config/config.exs`.
+
+      config :authsense, Myapp.User,
+        repo: Myapp.Repo
+
+  If you have more than one user, you can specify multiple configurations. (See `config/1` on info on how this is dealt with)
+
+      config :authsense, Myapp.User,
+        repo: Myapp.Repo
+
+      config :authsense, Myapp.AdminUser,
+        repo: Myapp.Repo
+
   These keys are available:
 
   - `repo` (required) - the Ecto repo to connect to.
@@ -46,7 +59,9 @@ defmodule Authsense do
   - `identity_field` - field that identifies the user. (default: `:email`)
   - `password_field` - virtual field that has the plaintext password. (default: `:password`)
   - `hashed_password_field` - field where the password is stored. (default: `:hashed_password`)
-  - `login_error` - the error to add to the changeset on `Auth.authenticate/1`. (default: "Invalid credentials.")
+  - `login_error` - the error to add to the changeset on `Authsense.Service.authenticate/2`. (default: *"Invalid credentials."*)
+
+  `config/1` has more info on how config is used.
 
   ## Recipes
 
@@ -66,7 +81,7 @@ defmodule Authsense do
   }
 
   @doc """
-  Retrieves default configuration.
+  _Internal:_ Retrieves default configuration.
 
   See `config/1` for more info.
   """
@@ -75,7 +90,32 @@ defmodule Authsense do
   end
 
   @doc """
-  Retrieves configuration for a given model.
+  _Internal:_ Retrieves configuration for a given model.
+
+  ## Practical use
+
+  This is used internally by other functions to retrieve your configuration. For example,
+  you typically call `Authsense.Service.authenticate/2` with one parameter:
+
+      authenticate({"rico@gmail.com", "password"})
+
+  But you may pass options to it to override:
+
+      authenticate({"rico@gmail.com", "password"},
+        hashed_password_field: :hashed_password)
+
+  Or if you provide multiple models to Authsense, you can pick which one to use:
+
+      config :authsense,
+        Myapp.User, repo: MyApp.Repo
+
+      config :authsense,
+        Myapp.AdminUser, repo: MyApp.Repo
+
+      authenticate({"rico@gmail.com", "password"}, Myapp.User)
+      authenticate({"rico@gmail.com", "password"}, Myapp.AdminUser)
+
+  ## Internal use
 
       > Authsense.config
       %{ model: Example.User, repo: Example.Repo, ... }
@@ -89,6 +129,7 @@ defmodule Authsense do
 
       > Authsense.config(model: Example.User, foo: :bar)
       %{ model: Example.User, ... foo: :bar }
+
   """
   def config(nil) do
     [ conf | _ ] = all_env

--- a/lib/authsense.ex
+++ b/lib/authsense.ex
@@ -98,6 +98,10 @@ defmodule Authsense do
     |> Enum.into(@defaults)
   end
 
+  def config([]) do
+    config(nil)
+  end
+
   def config(opts) when is_list(opts) do
     model = opts[:model]
 

--- a/lib/authsense/plug.ex
+++ b/lib/authsense/plug.ex
@@ -52,20 +52,21 @@ defmodule Authsense.Plug do
   @doc """
   Sets the current user for the session.
 
+      import Authsense.Plug
+
       conn
-      |> Auth.put_current_user(user)
+      |> put_current_user(user)
       |> put_flash(:info, "Welcome.")
       |> redirect(to: "/")
 
   To logout, set it to nil.
 
       conn
-      |> Auth.put_current_user(nil)
+      |> put_current_user(nil)
       |> put_flash(:info, "You've been logged out.")
       |> redirect(to: "/")
 
-  This sets the `:current_user_id` in the Session store. To access the User
-  model, use `Auth` as a plug (see `Authsense.Plug`).
+  This sets the `:current_user_id` in the Session store.
   """
   def put_current_user(conn, nil) do
     conn

--- a/lib/authsense/plug.ex
+++ b/lib/authsense/plug.ex
@@ -1,6 +1,18 @@
 defmodule Authsense.Plug do
   @moduledoc """
-  See `Authsense.call/2`.
+  Plug helpers for Authsense.
+
+  You can use most of these functions as plugs.
+
+      # in your controller or pipeline:
+      import Authsense.Plug
+      plug :fetch_current_user
+
+  You can specify additional options.
+
+      plug :fetch_current_user,
+        repo: MyApp.Repo,
+        model: MyApp.User
   """
 
   import Plug.Conn, only:
@@ -9,12 +21,8 @@ defmodule Authsense.Plug do
   @doc """
   Sets the `:current_user` assigns variable based on session.
 
-      defmodule Auth do
-        use Authsense, # ...
-      end
-
       # in your controller or pipeline:
-      import Auth
+      import Authsense.Plug
       plug :fetch_current_user
 
   By doing so, you'll get access to the `:current_user` assigns. It will be set

--- a/lib/authsense/plug.ex
+++ b/lib/authsense/plug.ex
@@ -18,6 +18,8 @@ defmodule Authsense.Plug do
   import Plug.Conn, only:
     [get_session: 2, put_session: 3, delete_session: 2, assign: 3]
 
+  alias Plug.Conn
+
   @doc """
   Sets the `:current_user` assigns variable based on session.
 
@@ -36,11 +38,13 @@ defmodule Authsense.Plug do
         You are not logged in.
       <% end %>
   """
-  def fetch_current_user(%Plug.Conn{assigns: %{ current_user: _ }} = conn, _) do
+  def fetch_current_user(conn, opts \\ [])
+  def fetch_current_user(%Conn{assigns: %{ current_user: _ }} = conn, _) do
+    # Already ran fetch_current_user; no need to do so again.
     conn
   end
 
-  def fetch_current_user(conn, opts \\ []) do
+  def fetch_current_user(conn, opts) do
     %{repo: repo, model: model} = Authsense.config(opts)
 
     case get_session(conn, :current_user_id) do

--- a/lib/authsense/plug.ex
+++ b/lib/authsense/plug.ex
@@ -32,7 +32,9 @@ defmodule Authsense.Plug do
     conn
   end
 
-  def fetch_current_user(conn, %{model: model, repo: repo}) do
+  def fetch_current_user(conn, opts \\ []) do
+    %{repo: repo, model: model} = Authsense.config(opts)
+
     case get_session(conn, :current_user_id) do
       nil ->
         assign(conn, :current_user, nil)

--- a/lib/authsense/plug.ex
+++ b/lib/authsense/plug.ex
@@ -7,7 +7,26 @@ defmodule Authsense.Plug do
     [get_session: 2, put_session: 3, delete_session: 2, assign: 3]
 
   @doc """
-  Adds `:current_user` to the assigns.
+  Sets the `:current_user` assigns variable based on session.
+
+      defmodule Auth do
+        use Authsense, # ...
+      end
+
+      # in your controller or pipeline:
+      import Auth
+      plug :fetch_current_user
+
+  By doing so, you'll get access to the `:current_user` assigns. It will be set
+  to the User model if logged in, or to `nil` if logged out.
+
+      conn.assigns.current_user
+
+      <%= if @current_user %>
+        Hello, <%= @current_user.name %>
+      <% else %>
+        You are not logged in.
+      <% end %>
   """
   def fetch_current_user(%Plug.Conn{assigns: %{ current_user: _ }} = conn, _) do
     conn
@@ -29,7 +48,22 @@ defmodule Authsense.Plug do
   end
 
   @doc """
-  See `Authsense.put_current_user/2`.
+  Sets the current user for the session.
+
+      conn
+      |> Auth.put_current_user(user)
+      |> put_flash(:info, "Welcome.")
+      |> redirect(to: "/")
+
+  To logout, set it to nil.
+
+      conn
+      |> Auth.put_current_user(nil)
+      |> put_flash(:info, "You've been logged out.")
+      |> redirect(to: "/")
+
+  This sets the `:current_user_id` in the Session store. To access the User
+  model, use `Auth` as a plug (see `Authsense.Plug`).
   """
   def put_current_user(conn, nil) do
     conn

--- a/lib/authsense/plug.ex
+++ b/lib/authsense/plug.ex
@@ -51,12 +51,7 @@ defmodule Authsense.Plug do
       nil ->
         assign(conn, :current_user, nil)
       id ->
-        user = try do
-          repo.get!(model, id)
-        rescue _ ->
-          # Protection against "logged in" users whos accounts get deleted.
-          nil
-        end
+        user = repo.get(model, id)
         assign(conn, :current_user, user)
     end
   end

--- a/lib/authsense/service.ex
+++ b/lib/authsense/service.ex
@@ -2,6 +2,8 @@ defmodule Authsense.Service do
   import Ecto.Changeset, only:
     [get_change: 2, put_change: 3, validate_change: 3]
 
+  alias Ecto.Changeset
+
   @doc """
   Checks if someone can authenticate with a given username/password pair.
 
@@ -50,7 +52,7 @@ defmodule Authsense.Service do
       authenticate_user({ email, password })
   """
   def authenticate_user(changeset_or_tuple, model \\ nil)
-  def authenticate_user(%Ecto.Changeset{} = changeset, model) do
+  def authenticate_user(%Changeset{} = changeset, model) do
     %{identity_field: id, password_field: passwd} =
       Authsense.config(model)
 
@@ -109,7 +111,7 @@ defmodule Authsense.Service do
   Also see `Authsense.Service.generate_hashed_password/2` for the underlying
   implementation.
   """
-  def generate_hashed_password(%Ecto.Changeset{} = changeset, model \\ nil) do
+  def generate_hashed_password(%Changeset{} = changeset, model \\ nil) do
     %{password_field: passwd, hashed_password_field: hashed_passwd,
       crypto: crypto} = Authsense.config(model)
 
@@ -122,7 +124,10 @@ defmodule Authsense.Service do
     end
   end
 
-  defp auth_failure(%Ecto.Changeset{} = changeset, model \\ nil) do
+  # Adds errors to a changeset.
+  # Used by `authenticate/2`.
+  defp auth_failure(changeset_or_tuple, model \\ nil)
+  defp auth_failure(%Changeset{} = changeset, model) do
     %{password_field: passwd, login_error: login_error} =
       Authsense.config(model)
 

--- a/lib/authsense/service.ex
+++ b/lib/authsense/service.ex
@@ -50,13 +50,34 @@ defmodule Authsense.Service do
   end
 
   @doc """
-  See `Authsense.generate_hashed_password/1`.
+  Updates an `Ecto.Changeset` to generate a hashed password.
+  
+  If the changeset has `:password` in it, it will be hashed and stored as
+  `:hashed_password`.  (Fields can be configured in `Authsense`.)
+
+      changeset
+      |> Auth.generate_hashed_password()
+
+  It's typically used in a model's `changeset/2` function.
+
+      defmodule Example.User do
+        use Example.Web, :model
+
+        def changeset(model, params \\ :empty) do
+          model
+          |> cast(params, @required_fields, @optional_fields)
+          |> Auth.generate_hashed_password()
+          |> validate_confirmation(:password, message: "password confirmation doesn't match")
+          |> unique_constraint(:email)
+        end
+      end
+
+  Also see `Authsense.Service.generate_hashed_password/2` for the underlying
+  implementation.
   """
-  def generate_hashed_password(
-    %Ecto.Changeset{} = changeset,
+  def generate_hashed_password(%Ecto.Changeset{} = changeset) do
     %{password_field: passwd, hashed_password_field: hashed_passwd,
-      crypto: crypto})
-  do
+      crypto: crypto} = Authsense.config
     case get_change(changeset, passwd) do
       nil ->
         changeset

--- a/lib/authsense/service.ex
+++ b/lib/authsense/service.ex
@@ -11,12 +11,14 @@ defmodule Authsense.Service do
   @doc """
   Checks if someone can authenticate with a given username/password pair.
 
-  Works on both Ecto changesets or tuples.
+  Credentials can be given as either an Ecto changeset or a tuple.
 
+      # Changeset:
       %User{}
       |> change(%{ email: "rico@gmail.com", password: "password" })
       |> authenticate()
 
+      # Tuple:
       authenticate({ "rico@gmail.com", "password" })
 
   Returns `{:ok, user}` on success, or `{:error, changeset}` on failure. If
@@ -39,7 +41,8 @@ defmodule Authsense.Service do
         end
       end
   """
-  def authenticate(credentials, model \\ nil) do
+  def authenticate(changeset_or_tuple, model \\ nil)
+  def authenticate(credentials, model) do
     case authenticate_user(credentials, model) do
       false -> {:error, auth_failure(credentials, model)}
       user -> {:ok, user}
@@ -127,7 +130,6 @@ defmodule Authsense.Service do
 
   # Adds errors to a changeset.
   # Used by `authenticate/2`.
-  defp auth_failure(changeset_or_tuple, model \\ nil)
   defp auth_failure(%Changeset{} = changeset, model) do
     %{password_field: passwd, login_error: login_error} =
       Authsense.config(model)

--- a/lib/authsense/service.ex
+++ b/lib/authsense/service.ex
@@ -37,7 +37,7 @@ defmodule Authsense.Service do
   """
   def authenticate(credentials, model \\ nil) do
     case authenticate_user(credentials, model) do
-      false -> {:error, auth_failure(credentials)}
+      false -> {:error, auth_failure(credentials, model)}
       user -> {:ok, user}
     end
   end
@@ -87,7 +87,7 @@ defmodule Authsense.Service do
 
   @doc """
   Updates an `Ecto.Changeset` to generate a hashed password.
-  
+
   If the changeset has `:password` in it, it will be hashed and stored as
   `:hashed_password`.  (Fields can be configured in `Authsense`.)
 

--- a/lib/mix/tasks/authsense.gen.ex_
+++ b/lib/mix/tasks/authsense.gen.ex_
@@ -3,9 +3,7 @@ defmodule Mix.Tasks.Authsense.Gen do
 
   @shortdoc "Eats chocolate"
 
-  @moduledoc """
-  I like turtles
-  """
+  @moduledoc false
 
   @defaults %{
     model: "User",

--- a/test/authsense_test.exs
+++ b/test/authsense_test.exs
@@ -43,7 +43,7 @@ defmodule AuthsenseTest do
 
     assert {:ok, get_user} == %User{}
     |> change(%{email: "rico@gmail.com", password: "foobar"})
-    |> Auth.authenticate()
+    |> Authsense.Service.authenticate()
   end
 
   test "authenticate via changeset failure" do
@@ -51,7 +51,7 @@ defmodule AuthsenseTest do
 
     {:error, changeset} = %User{}
     |> change(%{email: "rico@gmail.com", password: "nope"})
-    |> Auth.authenticate()
+    |> Authsense.Service.authenticate()
 
     assert changeset.errors == [password: "Invalid credentials."]
   end
@@ -59,16 +59,16 @@ defmodule AuthsenseTest do
   test "authenticate via password" do
     add_user
 
-    assert {:error, nil} == Auth.authenticate({"rico@gmail.com", "nope"})
+    assert {:error, nil} == Authsense.Service.authenticate({"rico@gmail.com", "nope"})
   end
 
   test "get_user" do
     add_user
-    assert Auth.get_user("rico@gmail.com") == get_user
+    assert Authsense.Service.get_user("rico@gmail.com") == get_user
   end
 
   test "get_user failure" do
-    assert Auth.get_user("nobody@gmail.com") == nil
+    assert Authsense.Service.get_user("nobody@gmail.com") == nil
   end
 
   @tag :pending

--- a/test/authsense_test.exs
+++ b/test/authsense_test.exs
@@ -1,81 +1,13 @@
 defmodule AuthsenseTest do
   use ExUnit.Case
   doctest Authsense
-  alias Authsense.Test.Repo
-  alias Authsense.Test.User
-  import Ecto.Changeset, only: [change: 2]
-
-  setup do
-    Repo.delete_all(User)
-    :ok
-  end
-
-  def add_user do
-    %User{}
-    |> change(%{email: "rico@gmail.com", password: "foobar"})
-    |> Authsense.Service.generate_hashed_password()
-    |> Repo.insert!
-  end
-
-  def get_user do
-    Repo.get_by(User, email: "rico@gmail.com")
-  end
-
-  test "generate_hashed_password success" do
-    add_user
-
-    user = Repo.get_by(User, email: "rico@gmail.com")
-    assert user.hashed_password |> String.starts_with?("$pbkdf2-sha512$")
-  end
-
-  test "generate_hashed_password failure" do
-    %User{}
-    |> change(%{email: "rico@gmail.com"})
-    |> Authsense.Service.generate_hashed_password()
-    |> Repo.insert!
-
-    user = Repo.get_by(User, email: "rico@gmail.com")
-    assert user.hashed_password == nil
-  end
-
-  test "authenticate via changeset" do
-    add_user
-
-    assert {:ok, get_user} == %User{}
-    |> change(%{email: "rico@gmail.com", password: "foobar"})
-    |> Authsense.Service.authenticate()
-  end
-
-  test "authenticate via changeset failure" do
-    add_user
-
-    {:error, changeset} = %User{}
-    |> change(%{email: "rico@gmail.com", password: "nope"})
-    |> Authsense.Service.authenticate()
-
-    assert changeset.errors == [password: "Invalid credentials."]
-  end
-
-  test "authenticate via password" do
-    add_user
-
-    assert {:error, nil} == Authsense.Service.authenticate({"rico@gmail.com", "nope"})
-  end
-
-  test "get_user" do
-    add_user
-    assert Authsense.Service.get_user("rico@gmail.com") == get_user
-  end
-
-  test "get_user failure" do
-    assert Authsense.Service.get_user("nobody@gmail.com") == nil
-  end
 
   @tag :pending
   test "put_current_user"
+
   @tag :pending
   test "fetch_current_user"
 
   @tag :pending
-  test "plug"
+  test "config"
 end

--- a/test/authsense_test.exs
+++ b/test/authsense_test.exs
@@ -13,7 +13,7 @@ defmodule AuthsenseTest do
   def add_user do
     %User{}
     |> change(%{email: "rico@gmail.com", password: "foobar"})
-    |> Auth.generate_hashed_password()
+    |> Authsense.Service.generate_hashed_password()
     |> Repo.insert!
   end
 
@@ -31,7 +31,7 @@ defmodule AuthsenseTest do
   test "generate_hashed_password failure" do
     %User{}
     |> change(%{email: "rico@gmail.com"})
-    |> Auth.generate_hashed_password()
+    |> Authsense.Service.generate_hashed_password()
     |> Repo.insert!
 
     user = Repo.get_by(User, email: "rico@gmail.com")

--- a/test/authsense_test.exs
+++ b/test/authsense_test.exs
@@ -30,6 +30,11 @@ defmodule AuthsenseTest do
     assert config.foo == :bar
   end
 
+  test "accepts empty lists" do
+    config = Authsense.config([])
+    assert config.model == Authsense.Test.User
+  end
+
   @tag :pending
   test "put_current_user"
 

--- a/test/authsense_test.exs
+++ b/test/authsense_test.exs
@@ -2,6 +2,34 @@ defmodule AuthsenseTest do
   use ExUnit.Case
   doctest Authsense
 
+  test "config(nil)" do
+    config = Authsense.config
+    assert config.model == Authsense.Test.User
+    assert config.repo == Authsense.Test.Repo
+  end
+
+  test "sets defaults" do
+    config = Authsense.config
+    assert config.identity_field == :email
+  end
+
+  test "accepts models" do
+    config = Authsense.config(Authsense.Test.User)
+    assert config.model == Authsense.Test.User
+  end
+
+  test "works even if config for model isn't set" do
+    config = Authsense.config(Exunit)
+    assert config.repo == nil
+    assert config.model == Exunit
+  end
+
+  test "accepts lists" do
+    config = Authsense.config(model: Authsense.Test.User, foo: :bar)
+    assert config.model == Authsense.Test.User
+    assert config.foo == :bar
+  end
+
   @tag :pending
   test "put_current_user"
 

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -1,0 +1,59 @@
+defmodule PlugTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+  import Ecto.Changeset, only: [change: 2]
+
+  alias Authsense.Test.Repo
+  alias Authsense.Test.User
+  alias Authsense.Test.ProcessStore
+  alias Authsense.Service
+
+  setup do
+    Repo.delete_all(User)
+    :ok
+  end
+
+  defp add_user do
+    %User{}
+    |> change(%{email: "rico@gmail.com", password: "foobar"})
+    |> Service.generate_hashed_password()
+    |> Repo.insert!
+  end
+
+  # Enables sessions in a conn
+  defp sign_conn(conn) do
+    opts = Plug.Session.init(store: ProcessStore, key: "foobar")
+    conn
+    |> Plug.Session.call(opts)
+    |> fetch_session
+  end
+
+  test "put_current_user(user)" do
+    user = add_user
+    conn = conn(:get, "/")
+    |> sign_conn()
+    |> Authsense.Plug.put_current_user(user)
+
+    assert conn.assigns.current_user == user
+    assert get_session(conn, :current_user_id) == user.id
+  end
+
+  test "put_current_user(nil)" do
+    conn = conn(:get, "/")
+    |> sign_conn()
+    |> Authsense.Plug.put_current_user(nil)
+
+    assert conn.assigns.current_user == nil
+    assert get_session(conn, :current_user_id) == nil
+  end
+
+  test "fetch_current_user" do
+    user = add_user
+    conn = conn(:get, "/")
+    |> sign_conn()
+    |> put_session(:current_user_id, user.id)
+    |> Authsense.Plug.fetch_current_user()
+
+    assert get_session(conn, :current_user_id) == user.id
+  end
+end

--- a/test/service_test.exs
+++ b/test/service_test.exs
@@ -1,0 +1,74 @@
+defmodule AuthsenseServiceTest do
+  use ExUnit.Case
+  doctest Authsense.Service
+  alias Authsense.Test.Repo
+  alias Authsense.Test.User
+  alias Authsense.Service
+  import Ecto.Changeset, only: [change: 2]
+
+  setup do
+    Repo.delete_all(User)
+    :ok
+  end
+
+  def add_user do
+    %User{}
+    |> change(%{email: "rico@gmail.com", password: "foobar"})
+    |> Service.generate_hashed_password()
+    |> Repo.insert!
+  end
+
+  def get_user do
+    Repo.get_by(User, email: "rico@gmail.com")
+  end
+
+  test "generate_hashed_password success" do
+    add_user
+
+    user = Repo.get_by(User, email: "rico@gmail.com")
+    assert user.hashed_password |> String.starts_with?("$pbkdf2-sha512$")
+  end
+
+  test "generate_hashed_password failure" do
+    %User{}
+    |> change(%{email: "rico@gmail.com"})
+    |> Service.generate_hashed_password()
+    |> Repo.insert!
+
+    user = Repo.get_by(User, email: "rico@gmail.com")
+    assert user.hashed_password == nil
+  end
+
+  test "authenticate via changeset" do
+    add_user
+
+    assert {:ok, get_user} == %User{}
+    |> change(%{email: "rico@gmail.com", password: "foobar"})
+    |> Service.authenticate()
+  end
+
+  test "authenticate via changeset failure" do
+    add_user
+
+    {:error, changeset} = %User{}
+    |> change(%{email: "rico@gmail.com", password: "nope"})
+    |> Service.authenticate()
+
+    assert changeset.errors == [password: "Invalid credentials."]
+  end
+
+  test "authenticate via password" do
+    add_user
+
+    assert {:error, nil} == Service.authenticate({"rico@gmail.com", "nope"})
+  end
+
+  test "get_user" do
+    add_user
+    assert Service.get_user("rico@gmail.com") == get_user
+  end
+
+  test "get_user failure" do
+    assert Service.get_user("nobody@gmail.com") == nil
+  end
+end

--- a/test/support/auth.ex
+++ b/test/support/auth.ex
@@ -1,5 +1,0 @@
-defmodule Auth do
-  use Authsense,
-    repo: Authsense.Test.Repo,
-    model: Authsense.Test.User
-end

--- a/test/support/process_store.ex
+++ b/test/support/process_store.ex
@@ -1,0 +1,31 @@
+defmodule Authsense.Test.ProcessStore do
+  @moduledoc """
+  Derived from:
+  https://github.com/elixir-lang/plug/blob/master/test/test_helper.exs
+  """
+
+  @behaviour Plug.Session.Store
+
+  def init(_opts) do
+    nil
+  end
+
+  def get(_conn, sid, nil) do
+    {sid, Process.get({:session, sid}) || %{}}
+  end
+
+  def delete(_conn, sid, nil) do
+    Process.delete({:session, sid})
+    :ok
+  end
+
+  def put(conn, nil, data, nil) do
+    sid = :crypto.strong_rand_bytes(96) |> Base.encode64
+    put(conn, sid, data, nil)
+  end
+
+  def put(_conn, sid, data, nil) do
+    Process.put({:session, sid}, data)
+    sid
+  end
+end


### PR DESCRIPTION
Authsense will now be configured through `config/config.exs`.

``` elixir
config :authsense,
  Authsense.Test.User,
  repo: Authsense.Test.Repo
```

Functions are now available via:

``` elixir
# before:
Auth.generate_hashed_password
Auth.fetch_current_user

# now:
Authsense.Service.generate_hashed_password
Authsense.Plug.fetch_current_user
```
## WIP
- [x] Move to the new configuration scheme
- [x] Update tests
- [x] Update documentation _(hold on, gimme a moment on this)_
