### PR TITLE
Fixes defaults not being overriden by config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,26 +2,4 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-if System.get_env("DATABASE_URL") do
-  config :authsense, Authsense.Test.Repo,
-    adapter: Ecto.Adapters.Postgres,
-    pool: Ecto.Adapters.SQL.Sandbox,
-    url: {:system, "DATABASE_URL"}
-else
-  config :authsense, Authsense.Test.Repo,
-    adapter: Ecto.Adapters.Postgres,
-    pool: Ecto.Adapters.SQL.Sandbox,
-    username: "postgres",
-    password: "postgres",
-    database: "authsense_test",
-    size: 10
-end
-
-config :ex_unit, :capture_log, true
-
-config :authsense,
-  Authsense.Test.User,
-  repo: Authsense.Test.Repo
-
-config :comeonin, :bcrypt_log_rounds, 4
-config :comeonin, :pbkdf2_rounds, 1
+if Mix.env == :test, do: import_config "test.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,4 +2,4 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-if Mix.env == :test, do: import_config "test.exs"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :authsense, Authsense.Test.User,
+  repo: Authsense.Test.Repo

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,26 +1,9 @@
 use Mix.Config
 
-if System.get_env("DATABASE_URL") do
-  config :authsense, Authsense.Test.Repo,
-    adapter: Ecto.Adapters.Postgres,
-    pool: Ecto.Adapters.SQL.Sandbox,
-    url: {:system, "DATABASE_URL"}
-else
-    config :authsense, Authsense.Test.Repo,
-      adapter: Ecto.Adapters.Postgres,
-      pool: Ecto.Adapters.SQL.Sandbox,
-      username: "postgres",
-      password: "postgres",
-      database: "authsense_test",
-      size: 10
-end
-
 config :ex_unit, :capture_log, true
 
-config :authsense,
-  Authsense.Test.User,
-  repo: Authsense.Test.Repo,
-  password_field: :custom_field
+config :authsense, Authsense.Test.User,
+  repo: Authsense.Test.Repo
 
 config :comeonin, :bcrypt_log_rounds, 4
 config :comeonin, :pbkdf2_rounds, 1

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,26 @@
+use Mix.Config
+
+if System.get_env("DATABASE_URL") do
+  config :authsense, Authsense.Test.Repo,
+    adapter: Ecto.Adapters.Postgres,
+    pool: Ecto.Adapters.SQL.Sandbox,
+    url: {:system, "DATABASE_URL"}
+else
+    config :authsense, Authsense.Test.Repo,
+      adapter: Ecto.Adapters.Postgres,
+      pool: Ecto.Adapters.SQL.Sandbox,
+      username: "postgres",
+      password: "postgres",
+      database: "authsense_test",
+      size: 10
+end
+
+config :ex_unit, :capture_log, true
+
+config :authsense,
+  Authsense.Test.User,
+  repo: Authsense.Test.Repo,
+  password_field: :custom_field
+
+config :comeonin, :bcrypt_log_rounds, 4
+config :comeonin, :pbkdf2_rounds, 1

--- a/lib/authsense.ex
+++ b/lib/authsense.ex
@@ -73,6 +73,19 @@ defmodule Authsense do
   things: see [Recipes](recipes.html).
   """
 
+  if Application.get_all_env(:authsense) == [] do
+    raise """
+    Please configure Authsense.
+
+    Example configuration:
+      config :authsense, MyApp.User,
+        repo: MyApp.Repo
+        identity_field: :email,
+        password_field: :password,
+        hashed_password_field: :hashed_password,
+    """
+  end
+
   @doc false
   @defaults %{
     crypto: Comeonin.Pbkdf2,
@@ -164,13 +177,7 @@ defmodule Authsense do
     |> Enum.into(@defaults)
   end
 
-  # Returns configuration concerning :authsense; strips away any configuration
-  # that doesn't fit.
   defp all_env do
     Application.get_all_env(:authsense)
-    |> Enum.filter(fn
-       {_model, [_] = list} -> Keyword.has_key?(list, :repo)
-       _ -> false
-    end)
   end
 end

--- a/lib/authsense/exceptions.ex
+++ b/lib/authsense/exceptions.ex
@@ -1,0 +1,51 @@
+defmodule Authsense.UnconfiguredException do
+  @moduledoc """
+  Raised when no configuration for `Authsense` is provided.
+  """
+  defexception [:message]
+
+  def exception(_) do
+    message = """
+    Please configure Authsense.
+
+        Example configuration:
+
+          config :authsense, MyApp.User,
+            repo: MyApp.Repo
+    """
+    %Authsense.UnconfiguredException{message: message}
+  end
+end
+
+defmodule Authsense.MultipleResourcesException do
+  @moduledoc """
+  When a single resource is configured for `Authsense`, it will
+  automatically use that resource for function calls that need
+  it, such as `Authsense.Service.generate_hashed_password/2`.
+
+  However, when multiple resources are configured, this exception
+  will be raised for functions that require a resource module as
+  `Authsense` will not be able to determine which resource to use
+  for that call.
+
+  This can be avoided by providing the correct resource module to
+  be used, e.g.,
+
+    `Authsense.Service.generate_hashed_password(changeset, User)`
+  """
+  defexception [:message]
+
+  def exception(_) do
+    resources =
+      Application.get_all_env(:authsense)
+      |> Enum.map(fn {resource, _} -> resource end)
+
+    message = """
+    Multiple resources are configured.
+
+        Authsense cannot determine which resource module to use.
+        Available resource modules: #{inspect resources}
+    """
+    %Authsense.MultipleResourcesException{message: message}
+  end
+end

--- a/test/authsense_test.exs
+++ b/test/authsense_test.exs
@@ -1,5 +1,5 @@
 defmodule AuthsenseTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   doctest Authsense
 
   setup do
@@ -7,49 +7,68 @@ defmodule AuthsenseTest do
 
     on_exit fn ->
       Application.delete_env :authsense, Admin
+      Application.put_env :authsense, Authsense.Test.User,
+        repo: Authsense.Test.Repo
     end
 
     :ok
   end
 
-  test "config(nil)" do
-    config = Authsense.config
-    assert config.model == Authsense.Test.User
-    assert config.repo == Authsense.Test.Repo
+  test "config with no resource configured" do
+    Application.delete_env :authsense, Authsense.Test.User
+
+    assert Authsense.config(Admin).model == Admin
+    assert_raise Authsense.UnconfiguredException, fn ->
+      Authsense.config
+    end
+  end
+
+  test "config with only one resource configured" do
+    assert Authsense.config.model == Authsense.Test.User
+    assert Authsense.config.repo == Authsense.Test.Repo
+  end
+
+  test "config with multiple resources configured" do
+    Application.put_env :authsense, Admin, password_field: :custom_field
+
+    assert Authsense.config(Admin).model == Admin
+    assert_raise Authsense.MultipleResourcesException, fn ->
+      Authsense.config
+    end
   end
 
   test "sets defaults" do
-    config = Authsense.config
-    assert config.identity_field == :email
+    assert Authsense.config.identity_field == :email
   end
 
   test "overrides defaults" do
-    Application.put_env :authsense, Admin,
-      password_field: :custom_field
-    config = Authsense.config(Admin)
-    assert config.password_field == :custom_field
-  end
+    Application.put_env :authsense, Admin, password_field: :custom_field
 
-  test "accepts models" do
-    config = Authsense.config(AnotherModule)
-    assert config.model == AnotherModule
-    assert config.password_field == :password
+    assert %{
+      model: Admin,
+      password_field: :custom_field,
+      repo: nil,
+      identity_field: :email
+    } = Authsense.config(Admin)
   end
 
   test "works even if config for model isn't set" do
-    config = Authsense.config(Exunit)
-    assert config.repo == nil
-    assert config.model == Exunit
+    assert %{
+      model: NotConfigured,
+      repo: nil,
+      identity_field: :email
+    } = Authsense.config(NotConfigured)
   end
 
   test "accepts lists" do
-    config = Authsense.config(model: AnotherModule, foo: :bar)
-    assert config.model == AnotherModule
-    assert config.foo == :bar
+    assert %{
+      model: NotConfigured,
+      foo: :bar,
+      identity_field: :email
+    } = Authsense.config(model: NotConfigured, foo: :bar)
   end
 
-  # test "accepts empty lists" do
-  #   config = Authsense.config([])
-  #   assert config.model == Authsense.Test.User
-  # end
+  test "accepts empty lists" do
+    assert Authsense.config([]).model == Authsense.Test.User
+  end
 end

--- a/test/authsense_test.exs
+++ b/test/authsense_test.exs
@@ -13,9 +13,15 @@ defmodule AuthsenseTest do
     assert config.identity_field == :email
   end
 
-  test "accepts models" do
+  test "overrides defaults" do
     config = Authsense.config(Authsense.Test.User)
-    assert config.model == Authsense.Test.User
+    assert config.password_field == :custom_field
+  end
+
+  test "accepts models" do
+    config = Authsense.config(AnotherModule)
+    assert config.model == AnotherModule
+    assert config.password_field == :password
   end
 
   test "works even if config for model isn't set" do
@@ -25,8 +31,8 @@ defmodule AuthsenseTest do
   end
 
   test "accepts lists" do
-    config = Authsense.config(model: Authsense.Test.User, foo: :bar)
-    assert config.model == Authsense.Test.User
+    config = Authsense.config(model: AnotherModule, foo: :bar)
+    assert config.model == AnotherModule
     assert config.foo == :bar
   end
 

--- a/test/authsense_test.exs
+++ b/test/authsense_test.exs
@@ -1,6 +1,16 @@
 defmodule AuthsenseTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Authsense
+
+  setup do
+    Application.delete_env :authsense, :included_applications
+
+    on_exit fn ->
+      Application.delete_env :authsense, Admin
+    end
+
+    :ok
+  end
 
   test "config(nil)" do
     config = Authsense.config
@@ -14,7 +24,9 @@ defmodule AuthsenseTest do
   end
 
   test "overrides defaults" do
-    config = Authsense.config(Authsense.Test.User)
+    Application.put_env :authsense, Admin,
+      password_field: :custom_field
+    config = Authsense.config(Admin)
     assert config.password_field == :custom_field
   end
 
@@ -36,8 +48,8 @@ defmodule AuthsenseTest do
     assert config.foo == :bar
   end
 
-  test "accepts empty lists" do
-    config = Authsense.config([])
-    assert config.model == Authsense.Test.User
-  end
+  # test "accepts empty lists" do
+  #   config = Authsense.config([])
+  #   assert config.model == Authsense.Test.User
+  # end
 end

--- a/test/support/models.ex
+++ b/test/support/models.ex
@@ -1,6 +1,6 @@
 defmodule Authsense.Test.User do
   use Ecto.Model
-  schema "users" do
+  schema "" do
     field :email, :string
     field :hashed_password, :string
     timestamps

--- a/test/support/repo.ex
+++ b/test/support/repo.ex
@@ -1,3 +1,26 @@
 defmodule Authsense.Test.Repo do
-  use Ecto.Repo, otp_app: :authsense
+  def start_link do
+    Agent.start_link fn -> [] end, name: :test_repo
+  end
+
+  def insert(%Ecto.Changeset{} = changeset) do
+    insert changeset.changes
+  end
+
+  def insert(resource) do
+    Agent.update :test_repo, fn state -> [resource|state] end
+    resource
+  end
+
+  def get(_model, id) do
+    Agent.get :test_repo, fn state ->
+      Enum.find(state, &(&1.id == id))
+    end
+  end
+
+  def get_by(_model, email: email) do
+    Agent.get :test_repo, fn state ->
+      Enum.find(state, &(&1.email == email))
+    end
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,9 +1,1 @@
 ExUnit.start()
-
-Mix.Task.run "ecto.drop", ["--quiet", "-r", "Authsense.Test.Repo"]
-Mix.Task.run "ecto.create", ["--quiet", "-r", "Authsense.Test.Repo"]
-Mix.Task.run "ecto.migrate", ["--quiet", "-r", "Authsense.Test.Repo"]
-
-Authsense.Test.Repo.start_link
-
-Ecto.Adapters.SQL.begin_test_transaction(Authsense.Test.Repo)


### PR DESCRIPTION
This also adds an error when Authsense is not configured at compile time. It was previously raising a no match error at runtime when it wasn't configured.
